### PR TITLE
Fix invalid import in two examples

### DIFF
--- a/ModelicaCompliance/Scoping/NameLookup/Composite/FunctionInOperatorLookupViaComp.mo
+++ b/ModelicaCompliance/Scoping/NameLookup/Composite/FunctionInOperatorLookupViaComp.mo
@@ -1,14 +1,14 @@
 within ModelicaCompliance.Scoping.NameLookup.Composite;
 
-model FunctionInOperatorLookupViaComp
-  extends Icons.TestCase;
-
-  operator record OR
+package FunctionInOperatorLookupViaComp
+  extends Icons.TestPackage;
+  
+  encapsulated operator record OR
     Real x;
 
     encapsulated operator '+'
       function add
-        import ModelicaCompliance.Scoping.NameLookup.Composite.FunctionLookupViaArrayElement.OR;
+        import ModelicaCompliance.Scoping.NameLookup.Composite.FunctionInOperatorLookupViaComp.OR;
         input OR or1;
         input OR or2;
         output OR result;
@@ -17,15 +17,17 @@ model FunctionInOperatorLookupViaComp
       end add;
     end '+';
   end OR;
+  model FunctionInOperatorLookupViaComp
+    extends Icons.TestCase;
+    OR or1(x = 1.0);
+    OR or2(x = 2.0);
+    OR or3 = or1.'+'.add(or1, or2);
 
-  OR or1(x = 1.0);
-  OR or2(x = 2.0);
-  OR or3 = or1.'+'.add(or1, or2);
-
-  annotation (
-    __ModelicaAssociation(TestCase(shouldPass = false, section = {"5.3.2"})),
-    experiment(StopTime = 0.01),
-    Documentation(
-      info = "<html>Checks that it's not allowed to look up a function in an operator
-        via a component.</html>"));
+    annotation (
+      __ModelicaAssociation(TestCase(shouldPass = false, section = {"5.3.2"})),
+      experiment(StopTime = 0.01),
+      Documentation(
+        info = "<html>Checks that it's not allowed to look up a function in an operator
+          via a component.</html>"));
+  end FunctionInOperatorLookupViaComp;
 end FunctionInOperatorLookupViaComp;

--- a/ModelicaCompliance/Scoping/NameLookup/Composite/OperatorFunctionLookupViaComp.mo
+++ b/ModelicaCompliance/Scoping/NameLookup/Composite/OperatorFunctionLookupViaComp.mo
@@ -1,13 +1,13 @@
 within ModelicaCompliance.Scoping.NameLookup.Composite;
 
-model OperatorFunctionLookupViaComp
-  extends Icons.TestCase;
-
+package OperatorFunctionLookupViaComp
+  extends Icons.TestPackage;
+ 
   operator record OR
     Real x;
 
     encapsulated operator function '+'
-      import ModelicaCompliance.Scoping.NameLookup.Composite.FunctionLookupViaArrayElement.OR;
+      import ModelicaCompliance.Scoping.NameLookup.Composite.OperatorFunctionLookupViaComp.OR;
       input OR or1;
       input OR or2;
       output OR result;
@@ -15,15 +15,18 @@ model OperatorFunctionLookupViaComp
       result := OR(x = or1.x + or2.x);
     end '+';
   end OR;
+  
+  model OperatorFunctionLookupViaComp
+    extends Icons.TestCase;
+    OR or1(x = 1.0);
+    OR or2(x = 2.0);
+    OR or3 = or1.'+'(or1, or2);
 
-  OR or1(x = 1.0);
-  OR or2(x = 2.0);
-  OR or3 = or1.'+'(or1, or2);
-
-  annotation (
-    __ModelicaAssociation(TestCase(shouldPass = false, section = {"5.3.2"})),
-    experiment(StopTime = 0.01),
-    Documentation(
-      info = "<html>Checks that it's not allowed to look up an operator function
-        via a component.</html>"));
+    annotation (
+      __ModelicaAssociation(TestCase(shouldPass = false, section = {"5.3.2"})),
+      experiment(StopTime = 0.01),
+      Documentation(
+        info = "<html>Checks that it's not allowed to look up an operator function
+          via a component.</html>"));
+  end OperatorFunctionLookupViaComp;
 end OperatorFunctionLookupViaComp;


### PR DESCRIPTION
Resolves #18 
Note that it is not merely a matter of fixing the path, since we cannot import 'Or' if it is placed in model.
Thus I had to reorganize the structure to add a package with the test-model and operator record inside.
Having the operator record somewhere else would seem nicer, but the idea is to have independent tests.