### PR TITLE
Different outer

### DIFF
--- a/ModelicaCompliance/Scoping/InnerOuter/MissingInnerMismatch.mo
+++ b/ModelicaCompliance/Scoping/InnerOuter/MissingInnerMismatch.mo
@@ -1,0 +1,44 @@
+within ModelicaCompliance.Scoping.InnerOuter;
+
+model MissingInnerMismatch
+  extends Icons.TestCase;
+
+  record R
+    Integer i;
+    
+    annotation (
+      defaultComponentName = "T0",
+      defaultComponentPrefixes = "inner",
+      missingInnerMessage = "The T0 inner variable is missing, adding record with Integer");
+  end R;
+  
+  record R2
+    Real i;
+    annotation (
+      defaultComponentName = "T0",
+      defaultComponentPrefixes = "inner",
+      missingInnerMessage = "The T0 inner variable is missing, adding record with Real");
+  end R2;
+  
+  class A
+    outer R T0;
+  end A;
+  
+  class A2
+    outer R2 T0;
+  end A2;
+
+  class B
+    A a;
+    A2 a2;
+  end B;
+
+  B b;
+
+equation 
+  T0.i = 1;
+  annotation (
+    __ModelicaAssociation(TestCase(shouldPass = false, section = {"5.4", "17.6"})),
+    experiment(StopTime = 0.01),
+    Documentation(info = "<html>Checks that missing inner is not added if different classes (with missingInnerMessage).</html>"));
+end MissingInnerMismatch;

--- a/ModelicaCompliance/Scoping/InnerOuter/MissingInnerMismatch2.mo
+++ b/ModelicaCompliance/Scoping/InnerOuter/MissingInnerMismatch2.mo
@@ -1,0 +1,35 @@
+within ModelicaCompliance.Scoping.InnerOuter;
+
+model MissingInnerMismatch2
+  extends Icons.TestCase;
+
+  record R
+    Integer i;
+  end R;
+  
+  record R2
+    Real i;
+  end R2;
+  
+  class A
+    outer R T0;
+  end A;
+  
+  class A2
+    outer R2 T0;
+  end A2;
+
+  class B
+    A a;
+    A2 a2;
+  end B;
+
+  B b;
+
+equation 
+  T0.i = 1;
+  annotation (
+    __ModelicaAssociation(TestCase(shouldPass = false, section = {"5.4", "17.6"})),
+    experiment(StopTime = 0.01),
+    Documentation(info = "<html>Checks that missing inner is not added if different classes (without missingInnerMessage).</html>"));
+end MissingInnerMismatch2;

--- a/ModelicaCompliance/Scoping/InnerOuter/package.order
+++ b/ModelicaCompliance/Scoping/InnerOuter/package.order
@@ -18,6 +18,8 @@ Record
 RecordWrong
 MissingInner
 MissingInnerAdded
+MissingInnerMismatch
+MissingInnerMismatch2
 OuterInPackage
 PartialInner
 PartialOuter


### PR DESCRIPTION
Test that we do not automatically add inner classes if different classes (with and without missingInnerMessage); related to #8.
Most importantly these new test-cases should still fail even with Modelica 3.4 rules.