### PR TITLE
TestImpure

### DIFF
--- a/ModelicaCompliance/Functions/External/CImpure.mo
+++ b/ModelicaCompliance/Functions/External/CImpure.mo
@@ -1,0 +1,22 @@
+within ModelicaCompliance.Functions.External;
+model CImpure
+  extends Icons.TestCase;
+  function impureFunction "The impure annotation should not be needed."
+     output Real y;
+     external "C";
+     annotation( __ModelicaAssociation_Impure=true,
+        Include="double impureFunction() {static double x=0;x+=1;return x;}");
+  end impureFunction;
+  Real x(start=0, fixed=true),y(start=1, fixed=true);
+equation
+  when sample(1e-3,1e-3) then
+     x=impureFunction();
+     y=x-pre(x);
+  end when;
+  assert(abs(y-1)<1e-3,"Difference should be 1");
+  annotation (
+    __ModelicaAssociation(TestCase(shouldPass = true, section = {"12.3"})),
+    experiment(StopTime = 0.01),
+    Documentation(
+      info = "<html>Test that functions in when-clauses are not optimized too much, causing problems for impure functions.</html>"));
+end CImpure;

--- a/ModelicaCompliance/Functions/External/package.order
+++ b/ModelicaCompliance/Functions/External/package.order
@@ -2,6 +2,7 @@ FortranLapack
 Builtin
 C
 CDefault
+CImpure
 CMapping1
 CMapping2
 CMapping3


### PR DESCRIPTION
This adds a test-case so that an impure function isn't optimized too much; based on a comment in #11.
It also uses the __ModelicaAssociation_Impure annotation from #16.