### PR TITLE
Correct reference in ModelicaCompliance.Components.Declarations.TypeNameAsComponentName

### DIFF
--- a/ModelicaCompliance/Components/Declarations/TypeNameAsComponentName.mo
+++ b/ModelicaCompliance/Components/Declarations/TypeNameAsComponentName.mo
@@ -9,7 +9,7 @@ package TypeNameAsComponentName
     x x = 1.0;
 
     annotation (
-      __ModelicaAssociation(TestCase(shouldPass = false, section = {"4.4.2"})),
+      __ModelicaAssociation(TestCase(shouldPass = false, section = {"4.2"})),
       experiment(StopTime = 0.01),
       Documentation(
         info = "<html>Checks that a component is not allowed to have the same


### PR DESCRIPTION
It is section 4.2 not 4.4.2 that state that a component may not have the same name as its type.

(For the specification it would be ideal if we could remove this specific rule, since it should follow from the lookup. Basically `x x;` should find the component x as its own type; and would thus be illegal similarly as `Real x;x y;` where the component x is the type of the component y.)