### PR TITLE
Should no longer combine input and stream

### DIFF
--- a/ModelicaCompliance/Components/Prefixes/StreamValidClassType.mo
+++ b/ModelicaCompliance/Components/Prefixes/StreamValidClassType.mo
@@ -1,5 +1,4 @@
 within ModelicaCompliance.Components.Prefixes;
-
 model StreamValidClassType
   extends Icons.TestCase;
 
@@ -8,7 +7,7 @@ model StreamValidClassType
   end R;
 
   connector C
-    input Real s = 3.0;
+    Real s;
   end C;
 
   connector CR
@@ -16,11 +15,11 @@ model StreamValidClassType
     flow Real f;
     stream R r;
   end CR;
-  
+
   connector CC
     Real e = 1.0;
     flow Real f;
-    stream C c;
+    stream C c(s=3.0);
   end CC;
 
   connector CV

--- a/ModelicaCompliance/Components/Prefixes/StreamValidClassType.mo
+++ b/ModelicaCompliance/Components/Prefixes/StreamValidClassType.mo
@@ -6,21 +6,11 @@ model StreamValidClassType
     Real s = 2.0;
   end R;
 
-  connector C
-    Real s;
-  end C;
-
   connector CR
     Real e = 1.0;
     flow Real f;
     stream R r;
   end CR;
-
-  connector CC
-    Real e = 1.0;
-    flow Real f;
-    stream C c(s=3.0);
-  end CC;
 
   connector CV
     Real e = 1.0;
@@ -29,7 +19,6 @@ model StreamValidClassType
   end CV;
 
   CR cr;
-  CC cc;
   CV cv;
 
   annotation (
@@ -37,5 +26,5 @@ model StreamValidClassType
     experiment(StopTime = 0.01),
     Documentation(
       info = "<html>Tests that the type prefix <pre>stream</pre> can be applied to
-        the allowed specialized classes type, record and connector.</html>"));
+      the allowed specialized classes type and record.</html>"));
 end StreamValidClassType;


### PR DESCRIPTION
Based on https://github.com/modelica/ModelicaSpecification/pull/3358 it doesn't make sense at all to combine stream and connector (with input). The specific combination of stream structured variable containing an input is also forbidden.
