### PR TITLE
Move external call annotations to where they belong

### DIFF
--- a/ModelicaCompliance/Functions/ExternalObjects/ExternalObjectTable.mo
+++ b/ModelicaCompliance/Functions/ExternalObjects/ExternalObjectTable.mo
@@ -9,16 +9,20 @@ model ExternalObjectTable
     function constructor
       input Real[:] vals;
       output MyTable outTable;
-
-      external "C" outTable = initMyTable(vals, size(vals, 1));
-      annotation(Include="#include \"ExtObjInit.c\"");
+    external "C"
+      outTable = initMyTable(vals, size(vals, 1))
+        annotation(
+          Include = "#include \"ExtObjInit.c\""
+        );
     end constructor;
 
     function destructor
       input MyTable inTable;
-
-      external "C" closeMyTable(inTable) ;
-      annotation(Include="#include \"ExtObjClose.c\"");
+    external "C"
+      closeMyTable(inTable)
+        annotation(
+          Include = "#include \"ExtObjClose.c\""
+        );
     end destructor;
   end MyTable;
 
@@ -26,9 +30,11 @@ model ExternalObjectTable
     input MyTable interpolTable;
     input Real u;
     output Real y;
-
-    external "C" y=interpolateMyTable(interpolTable,u) ;
-    annotation(Include="#include \"ExtObjInterpolate.c\"");
+  external "C"
+    y = interpolateMyTable(interpolTable, u)
+      annotation(
+        Include = "#include \"ExtObjInterpolate.c\""
+      );
   end interpolateMyTable;
 
   MyTable myTable = MyTable({5, 3, 1, 9, 6});

--- a/ModelicaCompliance/Functions/ExternalObjects/ExternalObjectTable.mo
+++ b/ModelicaCompliance/Functions/ExternalObjects/ExternalObjectTable.mo
@@ -10,8 +10,7 @@ model ExternalObjectTable
       input Real[:] vals;
       output MyTable outTable;
     external "C"
-      outTable = initMyTable(vals, size(vals, 1))
-        annotation(
+      outTable = initMyTable(vals, size(vals, 1)) annotation(
           Include = "#include \"ExtObjInit.c\""
         );
     end constructor;
@@ -19,8 +18,7 @@ model ExternalObjectTable
     function destructor
       input MyTable inTable;
     external "C"
-      closeMyTable(inTable)
-        annotation(
+      closeMyTable(inTable) annotation(
           Include = "#include \"ExtObjClose.c\""
         );
     end destructor;
@@ -31,8 +29,7 @@ model ExternalObjectTable
     input Real u;
     output Real y;
   external "C"
-    y = interpolateMyTable(interpolTable, u)
-      annotation(
+    y = interpolateMyTable(interpolTable, u) annotation(
         Include = "#include \"ExtObjInterpolate.c\""
       );
   end interpolateMyTable;

--- a/ModelicaCompliance/Functions/ExternalObjects/ExternalObjectTableInFunction.mo
+++ b/ModelicaCompliance/Functions/ExternalObjects/ExternalObjectTableInFunction.mo
@@ -13,8 +13,7 @@ model ExternalObjectTableInFunction
       input Real[:] vals;
       output MyTable outTable;
     external "C"
-      outTable = initMyTable(vals, size(vals, 1))
-        annotation(
+      outTable = initMyTable(vals, size(vals, 1)) annotation(
           Include = "#include \"ExtObjInit.c\""
         );
     end constructor;
@@ -22,8 +21,7 @@ model ExternalObjectTableInFunction
     function destructor
       input MyTable inTable;
     external "C"
-      closeMyTable(inTable)
-        annotation(
+      closeMyTable(inTable) annotation(
           Include = "#include \"ExtObjClose.c\""
         );
     end destructor;
@@ -34,8 +32,7 @@ model ExternalObjectTableInFunction
     input Real u;
     output Real y;
   external "C"
-    y = interpolateMyTable(interpolTable, u)
-      annotation(
+    y = interpolateMyTable(interpolTable, u) annotation(
         Include = "#include \"ExtObjInterpolate.c\""
       );
   end interpolateMyTable;

--- a/ModelicaCompliance/Functions/ExternalObjects/ExternalObjectTableInFunction.mo
+++ b/ModelicaCompliance/Functions/ExternalObjects/ExternalObjectTableInFunction.mo
@@ -12,16 +12,20 @@ model ExternalObjectTableInFunction
     function constructor
       input Real[:] vals;
       output MyTable outTable;
-
-      external "C" outTable = initMyTable(vals, size(vals, 1));
-      annotation(Include="#include \"ExtObjInit.c\"");
+    external "C"
+      outTable = initMyTable(vals, size(vals, 1))
+        annotation(
+          Include = "#include \"ExtObjInit.c\""
+        );
     end constructor;
 
     function destructor
       input MyTable inTable;
-
-      external "C" closeMyTable(inTable) ;
-      annotation(Include="#include \"ExtObjClose.c\"");
+    external "C"
+      closeMyTable(inTable)
+        annotation(
+          Include = "#include \"ExtObjClose.c\""
+        );
     end destructor;
   end MyTable;
 
@@ -29,9 +33,11 @@ model ExternalObjectTableInFunction
     input MyTable interpolTable;
     input Real u;
     output Real y;
-
-    external "C" y=interpolateMyTable(interpolTable,u) ;
-    annotation(Include="#include \"ExtObjInterpolate.c\"");
+  external "C"
+    y = interpolateMyTable(interpolTable, u)
+      annotation(
+        Include = "#include \"ExtObjInterpolate.c\""
+      );
   end interpolateMyTable;
 
   function interpolateMyTableFunc


### PR DESCRIPTION
Loosely related to specification clarification:
- https://github.com/modelica/ModelicaSpecification/pull/3642
